### PR TITLE
Fixed "Ram Available" value in GetRamUsage()

### DIFF
--- a/memory.go
+++ b/memory.go
@@ -13,7 +13,7 @@ func GetRamUsage() {
 	}
 	usedPercent := fmt.Sprintf("%f", m.UsedPercent)
 	ResultPrinter("Ram Used: ", usedPercent+"%")
-	ResultPrinter("Ram Available: ", m.Used)
+	ResultPrinter("Ram Available: ", m.Free)
 }
 
 //func GetTopProcesses() {


### PR DESCRIPTION
Regarding issue #12 

The value is now correct, the "Ram Available" displays free RAM instead of used 