### PR TITLE
Add Public IPv4 Address in Network, Error Handling in CPU/Memory/Network, Executable Files in GitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 go.sum
 .idea/
+termiboard.exe
+termiboard

--- a/cpu.go
+++ b/cpu.go
@@ -10,10 +10,12 @@ import (
 //	//Implement function to get the current temperature of CPU
 //}
 //
+
 func GetCpuUsage() {
 	cpuPercent, err := cpu.Percent(time.Second, false)
 	if err != nil {
 		StandardPrinter(ErrorRedColor, "Could not retrieve CPU usage details.")
+		panic(err) //Exit upon error, below code must not be executed
 	}
 	usedPercent := fmt.Sprintf("%.2f", cpuPercent[0])
 	ResultPrinter("CPU Usage: ", usedPercent+"%")
@@ -23,8 +25,8 @@ func GetCpuInfo() {
 	cpuInfo, err := cpu.Info()
 	if err != nil {
 		StandardPrinter(ErrorRedColor, "Could not retrieve CPU details.")
+		panic(err) //Exit upon error, below code must not be executed
 	}
 	ResultPrinter("CPU Model: ", cpuInfo[0].ModelName)
 	ResultPrinter("CPU Cores: ", cpuInfo[0].Cores)
-
 }

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	GetCpuUsage()
 	GetRamUsage()
 	GetDiskUsage()
-	ResultPrinter("Public IPv4 Address: ",GetPublicIPAddress())
+	GetPublicIPAddress()
 }
 
 func printBanner() {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ func main() {
 	GetCpuUsage()
 	GetRamUsage()
 	GetDiskUsage()
+	ResultPrinter("Public IPv4 Address: ",GetPublicIPAddress())
 }
 
 func printBanner() {

--- a/memory.go
+++ b/memory.go
@@ -11,6 +11,7 @@ func GetRamUsage() {
 	m, err := mem.VirtualMemory()
 	if err != nil {
 		StandardPrinter(ErrorRedColor, "Could not retrieve RAM details.")
+		panic(err) //Exit upon error, below code must not be executed
 	}
 	usedPercent := fmt.Sprintf("%f", m.UsedPercent)
 	ResultPrinter("Ram Used: ", usedPercent+"%")
@@ -25,6 +26,7 @@ func GetDiskUsage() {
 	diskUsage, err := disk.Usage("/")
 	if err != nil {
 		StandardPrinter(ErrorRedColor, "Could not retrieve disk usage details.")
+		panic(err) //Exit upon error, below code must not be executed
 	}
 	usedPercent := fmt.Sprintf("%.2f", diskUsage.UsedPercent)
 	ResultPrinter("Disk Usage: ", usedPercent+"%")

--- a/network.go
+++ b/network.go
@@ -5,7 +5,7 @@ import (
   "net/http"
 )
 
-func GetPublicIPAddress() string {
+func GetPublicIPAddress() {
   URL := "https://api.ipify.org" //Using Third Party Service to Ping
   resp, err := http.Get(URL) //Get the JSON Response
   if err != nil {
@@ -19,8 +19,7 @@ func GetPublicIPAddress() string {
     StandardPrinter(ErrorRedColor, "Could not find IPv4 Address")
     panic(err) //Exit upon error, below code must not be executed
   }
-
-  return string(IP) //Cast []bByte to String and return
+  ResultPrinter("Public IPv4 Address: ",string(IP)) //Cast []bByte to String and return
 }
 
 //func GetLocalIPAddress() {

--- a/network.go
+++ b/network.go
@@ -1,11 +1,28 @@
 package main
 
-//func GetPublicIPAddress() {
-//	//Implement the function to return the public address of the pc.
-//	//Do not forget to handle errors if the pc isn't connected to a public network!
-//	// You will need to return a String.
-//}
-//
+import (
+  "io/ioutil"
+  "net/http"
+)
+
+func GetPublicIPAddress() string {
+  URL := "https://api.ipify.org" //Using Third Party Service to Ping
+  resp, err := http.Get(URL) //Get the JSON Response
+  if err != nil {
+    StandardPrinter(ErrorRedColor, "Could not get response from " + URL)
+    StandardPrinter(WarningYellowColor, "Check your Internet Connection")
+    panic(err) //Exit upon error, below code must not be executed
+  }
+  defer resp.Body.Close() //The client must close the response body when finished with it
+  IP, err := ioutil.ReadAll(resp.Body) //Reading all data from a io.Reader until EOF
+  if err != nil {
+    StandardPrinter(ErrorRedColor, "Could not find IPv4 Address")
+    panic(err) //Exit upon error, below code must not be executed
+  }
+
+  return string(IP) //Cast []bByte to String and return
+}
+
 //func GetLocalIPAddress() {
 //	//Implement to function to return the local IP Address of the pc.
 //	// You will need to return a String.


### PR DESCRIPTION
Fixes #5 

- [x] Added Get Public IPv4 Address function in network.go

- [x] Added `panic(err)` in every error handling block, because even after the error the function didn't return to main and continued to execute the below lines of code. If it is more verbose `panic(err)` can be replaced safely with `return`

- [x] Git was tracking, staging and committing executable and binaries so, I have added a rule in .gitignore to not track them.