### PR TITLE
feat: Add support for reading options from flags

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -12,21 +12,27 @@ import (
 //
 
 func GetCpuUsage() {
-	cpuPercent, err := cpu.Percent(time.Second, false)
-	if err != nil {
-		StandardPrinter(ErrorRedColor, "Could not retrieve CPU usage details.")
-		panic(err) //Exit upon error, below code must not be executed
+	if *showAll || *showCPUUsage {
+		cpuPercent, err := cpu.Percent(time.Second, false)
+		if err != nil {
+			StandardPrinter(ErrorRedColor, "Could not retrieve CPU usage details.")
+			panic(err) //Exit upon error, below code must not be executed
+		}
+		usedPercent := fmt.Sprintf("%.2f", cpuPercent[0])
+		ResultPrinter("CPU Usage: ", usedPercent+"%")
 	}
-	usedPercent := fmt.Sprintf("%.2f", cpuPercent[0])
-	ResultPrinter("CPU Usage: ", usedPercent+"%")
 }
 
 func GetCpuInfo() {
-	cpuInfo, err := cpu.Info()
-	if err != nil {
-		StandardPrinter(ErrorRedColor, "Could not retrieve CPU details.")
-		panic(err) //Exit upon error, below code must not be executed
+	if *showAll || *showCPUInfo {
+		cpuInfo, err := cpu.Info()
+		if err != nil {
+			StandardPrinter(ErrorRedColor, "Could not retrieve CPU details.")
+			panic(err) //Exit upon error, below code must not be executed
+		}
+
+		ResultPrinter("CPU Model: ", cpuInfo[0].ModelName)
+		ResultPrinter("CPU Cores: ", cpuInfo[0].Cores)
+
 	}
-	ResultPrinter("CPU Model: ", cpuInfo[0].ModelName)
-	ResultPrinter("CPU Cores: ", cpuInfo[0].Cores)
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+)
 
 const (
 	InfoOrangeColor    = "\033[1;34m%s\033[0m"
@@ -9,7 +12,31 @@ const (
 	ErrorRedColor      = "\033[1;31m%s\033[0m"
 )
 
+var (
+	showCPUInfo  *bool
+	showCPUUsage *bool
+	showRAM      *bool
+	showDisk     *bool
+	showLocalIP  *bool
+	showPublicIP *bool
+	showAll      *bool
+)
+
 func main() {
+	//init flags
+	showCPUInfo = flag.Bool("cpu-info", false, "Show CPU information")
+	showCPUUsage = flag.Bool("cpu-usage", false, "Show CPU usage")
+	showRAM = flag.Bool("ram", false, "Show RAM usage")
+	showDisk = flag.Bool("disk", false, "Show disk usage")
+	showLocalIP = flag.Bool("local-ip", false, "Show local IP address")
+	showPublicIP = flag.Bool("public-ip", false, "Show public IP address")
+	showAll = flag.Bool("all", false, "Show all stats")
+	flag.Parse()
+
+	if flag.NFlag() == 0 {
+		*showAll = true
+	}
+
 	printBanner()
 	StandardPrinter(WarningYellowColor, "v1.0")
 	GetCpuInfo()

--- a/memory.go
+++ b/memory.go
@@ -8,14 +8,16 @@ import (
 
 func GetRamUsage() {
 	//Implement the function to fetch ram usage - Total Ram used , free ram available and used percentage
-	m, err := mem.VirtualMemory()
-	if err != nil {
-		StandardPrinter(ErrorRedColor, "Could not retrieve RAM details.")
-		panic(err) //Exit upon error, below code must not be executed
+	if *showAll || *showRAM {
+		m, err := mem.VirtualMemory()
+		if err != nil {
+			StandardPrinter(ErrorRedColor, "Could not retrieve RAM details.")
+			panic(err) //Exit upon error, below code must not be executed
+		}
+		usedPercent := fmt.Sprintf("%f", m.UsedPercent)
+		ResultPrinter("Ram Used: ", usedPercent+"%")
+		ResultPrinter("Ram Available: ", m.Free)
 	}
-	usedPercent := fmt.Sprintf("%f", m.UsedPercent)
-	ResultPrinter("Ram Used: ", usedPercent+"%")
-	ResultPrinter("Ram Available: ", m.Free)
 }
 
 //func GetTopProcesses() {
@@ -23,12 +25,15 @@ func GetRamUsage() {
 //}
 //
 func GetDiskUsage() {
-	diskUsage, err := disk.Usage("/")
-	if err != nil {
-		StandardPrinter(ErrorRedColor, "Could not retrieve disk usage details.")
-		panic(err) //Exit upon error, below code must not be executed
+	if *showAll || *showDisk {
+		diskUsage, err := disk.Usage("/")
+		if err != nil {
+			StandardPrinter(ErrorRedColor, "Could not retrieve disk usage details.")
+			panic(err) //Exit upon error, below code must not be executed
+		}
+		usedPercent := fmt.Sprintf("%.2f", diskUsage.UsedPercent)
+		ResultPrinter("Disk Usage: ", usedPercent+"%")
+		ResultPrinter("Disk Space Available: ", diskUsage.Free)
+
 	}
-	usedPercent := fmt.Sprintf("%.2f", diskUsage.UsedPercent)
-	ResultPrinter("Disk Usage: ", usedPercent+"%")
-	ResultPrinter("Disk Space Available: ", diskUsage.Free)
 }

--- a/network.go
+++ b/network.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-  "io/ioutil"
-  "net/http"
-  "net"
+	"io/ioutil"
+	"net"
+	"net/http"
 )
 
 //func GetPublicIPAddress() string {
@@ -13,36 +13,40 @@ import (
 //}
 //
 func GetLocalIPAddress() {
-    addrs, err := net.InterfaceAddrs()
-    if err != nil {
-        StandardPrinter(ErrorRedColor, "Unfortunately it is not possible to get your local IP")
-    }
-    for _, address := range addrs {
-        // check the address type and if it is not a loopback the display it
-        if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-            if ipnet.IP.To4() != nil {
-		    ResultPrinter("Local IP Address: ", ipnet.IP.String())
-            }
-        }
-    }
+	if *showAll || *showLocalIP {
+		addrs, err := net.InterfaceAddrs()
+		if err != nil {
+			StandardPrinter(ErrorRedColor, "Unfortunately it is not possible to get your local IP")
+		}
+		for _, address := range addrs {
+			// check the address type and if it is not a loopback the display it
+			if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+				if ipnet.IP.To4() != nil {
+					ResultPrinter("Local IP Address: ", ipnet.IP.String())
+				}
+			}
+		}
 
+	}
 }
 
 func GetPublicIPAddress() {
-  URL := "https://api.ipify.org" //Using Third Party Service to Ping
-  resp, err := http.Get(URL) //Get the JSON Response
-  if err != nil {
-    StandardPrinter(ErrorRedColor, "Could not get response from " + URL)
-    StandardPrinter(WarningYellowColor, "Check your Internet Connection")
-    panic(err) //Exit upon error, below code must not be executed
-  }
-  defer resp.Body.Close() //The client must close the response body when finished with it
-  IP, err := ioutil.ReadAll(resp.Body) //Reading all data from a io.Reader until EOF
-  if err != nil {
-    StandardPrinter(ErrorRedColor, "Could not find IPv4 Address")
-    panic(err) //Exit upon error, below code must not be executed
-  }
-  ResultPrinter("Public IPv4 Address: ",string(IP)) //Cast []bByte to String and return
+	if *showAll || *showPublicIP {
+		URL := "https://api.ipify.org" //Using Third Party Service to Ping
+		resp, err := http.Get(URL)     //Get the JSON Response
+		if err != nil {
+			StandardPrinter(ErrorRedColor, "Could not get response from "+URL)
+			StandardPrinter(WarningYellowColor, "Check your Internet Connection")
+			panic(err) //Exit upon error, below code must not be executed
+		}
+		defer resp.Body.Close()              //The client must close the response body when finished with it
+		IP, err := ioutil.ReadAll(resp.Body) //Reading all data from a io.Reader until EOF
+		if err != nil {
+			StandardPrinter(ErrorRedColor, "Could not find IPv4 Address")
+			panic(err) //Exit upon error, below code must not be executed
+		}
+		ResultPrinter("Public IPv4 Address: ", string(IP)) //Cast []bByte to String and return
+	}
 }
 
 //


### PR DESCRIPTION
Users can now configure what information must be displayed ;)

The following flags must be passed while running the executable:
- `--all` - display all info
- `--cpu-info` - display CPU info
- `--cpu-usage` - display CPU usage
- `--ram` - display RAM info
- `--disk` - display disk info
- `--local-ip` - display local IP
- `--pubic-ip` - display public IP

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>