### PR TITLE
Add Network Interface Card Details

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ const (
 	BannerBlueColor    = "\033[1;36m%s\033[0m"
 	WarningYellowColor = "\033[1;33m%s\033[0m"
 	ErrorRedColor      = "\033[1;31m%s\033[0m"
-	BoldWhite					 = "\033[1;37m%s\033[0m"
-	None 							 = "\033[0m%s\033[0m"
+	BoldWhite          = "\033[1;37m%s\033[0m"
+	None               = "\033[0m%s\033[0m"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ const (
 	BannerBlueColor    = "\033[1;36m%s\033[0m"
 	WarningYellowColor = "\033[1;33m%s\033[0m"
 	ErrorRedColor      = "\033[1;31m%s\033[0m"
+	BoldWhite					 = "\033[1;37m%s\033[0m"
+	None 							 = "\033[0m%s\033[0m"
 )
 
 var (
@@ -56,6 +58,7 @@ func StandardPrinter(color string, message string) {
 	fmt.Printf(color, message)
 	fmt.Println("")
 }
+
 func ResultPrinter(title string, result interface{}) {
 	fmt.Printf(InfoOrangeColor, title)
 	fmt.Printf("%v", result)

--- a/network.go
+++ b/network.go
@@ -4,31 +4,8 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 )
-
-//func GetPublicIPAddress() string {
-//	//Implement the function to return the public address of the pc.
-//	//Do not forget to handle errors if the pc isn't connected to a public network!
-//	// You will need to return a String.
-//}
-//
-func GetLocalIPAddress() {
-	if *showAll || *showLocalIP {
-		addrs, err := net.InterfaceAddrs()
-		if err != nil {
-			StandardPrinter(ErrorRedColor, "Unfortunately it is not possible to get your local IP")
-		}
-		for _, address := range addrs {
-			// check the address type and if it is not a loopback the display it
-			if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-				if ipnet.IP.To4() != nil {
-					ResultPrinter("Local IP Address: ", ipnet.IP.String())
-				}
-			}
-		}
-
-	}
-}
 
 func GetPublicIPAddress() {
 	if *showAll || *showPublicIP {
@@ -46,6 +23,30 @@ func GetPublicIPAddress() {
 			panic(err) //Exit upon error, below code must not be executed
 		}
 		ResultPrinter("Public IPv4 Address: ", string(IP)) //Cast []bByte to String and return
+	}
+}
+
+func GetLocalIPAddress() {
+	if *showAll || *showLocalIP {
+		networkInterfaces, err := net.Interfaces() //Get the name of all Network Interface Cards
+		if err != nil { //Error Handling
+			StandardPrinter(ErrorRedColor, "Unfortunately it is not possible to get your local IP")
+			panic(err) //Exit upon error, below code must not be executed
+		}
+		ResultPrinter("Local IP Address:", "")
+		for _, networkInterface := range networkInterfaces { //Iterate over each Network Interface Card
+			StandardPrinter(BoldWhite,"\t[" + string(networkInterface.Name) + "] " + networkInterface.HardwareAddr.String()) // Print Name and Hardware Address
+			interfaceAddresses, err := networkInterface.Addrs() //Get the Internet Addresses of a Network Interface
+			if err == nil {
+				for _, interfaceAddress := range interfaceAddresses {
+					if(strings.Contains(interfaceAddress.String(), ".")) { //Check for IPv4 Address
+						StandardPrinter(None, "\t\t" + "IPv4" + " -> " + interfaceAddress.String())
+					} else if strings.Contains(interfaceAddress.String(), ":") { //Check for IPv6 Address
+						StandardPrinter(None, "\t\t" + "IPv6" + " -> " + interfaceAddress.String())
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/network.go
+++ b/network.go
@@ -29,20 +29,20 @@ func GetPublicIPAddress() {
 func GetLocalIPAddress() {
 	if *showAll || *showLocalIP {
 		networkInterfaces, err := net.Interfaces() //Get the name of all Network Interface Cards
-		if err != nil { //Error Handling
+		if err != nil {                            //Error Handling
 			StandardPrinter(ErrorRedColor, "Unfortunately it is not possible to get your local IP")
 			panic(err) //Exit upon error, below code must not be executed
 		}
 		ResultPrinter("Local IP Address:", "")
 		for _, networkInterface := range networkInterfaces { //Iterate over each Network Interface Card
-			StandardPrinter(BoldWhite,"\t[" + string(networkInterface.Name) + "] " + networkInterface.HardwareAddr.String()) // Print Name and Hardware Address
-			interfaceAddresses, err := networkInterface.Addrs() //Get the Internet Addresses of a Network Interface
+			StandardPrinter(BoldWhite, "\t["+string(networkInterface.Name)+"] "+networkInterface.HardwareAddr.String()) // Print Name and Hardware Address
+			interfaceAddresses, err := networkInterface.Addrs()                                                         //Get the Internet Addresses of a Network Interface
 			if err == nil {
 				for _, interfaceAddress := range interfaceAddresses {
-					if(strings.Contains(interfaceAddress.String(), ".")) { //Check for IPv4 Address
-						StandardPrinter(None, "\t\t" + "IPv4" + " -> " + interfaceAddress.String())
+					if strings.Contains(interfaceAddress.String(), ".") { //Check for IPv4 Address
+						StandardPrinter(None, "\t\t"+"IPv4"+" -> "+interfaceAddress.String())
 					} else if strings.Contains(interfaceAddress.String(), ":") { //Check for IPv6 Address
-						StandardPrinter(None, "\t\t" + "IPv6" + " -> " + interfaceAddress.String())
+						StandardPrinter(None, "\t\t"+"IPv6"+" -> "+interfaceAddress.String())
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #19 

- [x] Refactored `GetLocalIPAddress()` function to give details of Network Interface Cards along with IPv4, IPv6, and CIDR Block Details
- [x] Added Two Colors:

1. Bold White
2. Color Reset (Default)

## Output
![GitHubPR](https://user-images.githubusercontent.com/36518515/94857467-2a16d900-044f-11eb-8b46-ea0dc72cebd0.PNG)
