### PR TITLE
Print the 5 processes using more memory

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	showLocalIP  *bool
 	showPublicIP *bool
 	showAll      *bool
+	show5TopRAM  *bool
 )
 
 func main() {
@@ -32,6 +33,7 @@ func main() {
 	showDisk = flag.Bool("disk", false, "Show disk usage")
 	showLocalIP = flag.Bool("local-ip", false, "Show local IP address")
 	showPublicIP = flag.Bool("public-ip", false, "Show public IP address")
+	show5TopRAM = flag.Bool("top5-ram", false, "Show top 5 process that consume the most memory")
 	showAll = flag.Bool("all", false, "Show all stats")
 	flag.Parse()
 
@@ -47,6 +49,7 @@ func main() {
 	GetDiskUsage()
 	GetLocalIPAddress()
 	GetPublicIPAddress()
+	GetTopProcesses()
 }
 
 func printBanner() {

--- a/memory.go
+++ b/memory.go
@@ -38,7 +38,7 @@ func GetRamUsage() {
 
 // GetTopProcesses print out the top 5 process that are consuming most RAM
 func GetTopProcesses() {
-	if *showAll || *showDisk {
+	if *showAll || *show5TopRAM {
 		strOutput := ""
 		processes, err := process.Processes()
 		if err != nil {

--- a/memory.go
+++ b/memory.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"fmt"
+	"sort"
+
 	"github.com/shirou/gopsutil/disk"
 	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/process"
 )
 
 func getReadableSize(sizeInBytes uint64) (readableSizeString string) {
@@ -33,10 +36,42 @@ func GetRamUsage() {
 	}
 }
 
-//func GetTopProcesses() {
-//	//Implement this function to return top 5 process that are consuming the most ram
-//}
-//
+// GetTopProcesses print out the top 5 process that are consuming most RAM
+func GetTopProcesses() {
+	if *showAll || *showDisk {
+		strOutput := ""
+		processes, err := process.Processes()
+		if err != nil {
+			StandardPrinter(ErrorRedColor, "Could not retrieve running process list.")
+			panic(err)
+		}
+
+		sort.Slice(processes, func(i, j int) bool {
+			memoryPercentOfIthProcess, err := processes[i].MemoryPercent()
+			if err != nil {
+				StandardPrinter(ErrorRedColor, "Could not retrieve memory usage details.")
+				panic(err)
+			}
+			memoryPercentOfJthProcess, err := processes[j].MemoryPercent()
+			if err != nil {
+				StandardPrinter(ErrorRedColor, "Could not retrieve memory usage details.")
+				panic(err)
+			}
+			return memoryPercentOfIthProcess > memoryPercentOfJthProcess
+		})
+
+		for i := 0; i < 5; i++ {
+			memoryPercentOfIthProcess, err := processes[i].MemoryPercent()
+			if err != nil {
+				StandardPrinter(ErrorRedColor, "Could not retrieve memory usage details.")
+				panic(err)
+			}
+			strOutput += fmt.Sprintf("PID: %5d, memory %%: %2.1f\n", processes[i].Pid, memoryPercentOfIthProcess)
+		}
+		ResultPrinter("Top 5 processes by memory usage: \n", strOutput)
+	}
+}
+
 func GetDiskUsage() {
 	if *showAll || *showDisk {
 		diskUsage, err := disk.Usage("/")


### PR DESCRIPTION
It may not be the most efficient way as per the numbers of time I call MemoryPercent but it works and the output is the same as:  ```ps -eo pid,%mem --sort -%mem | head -6``` 

Resolves #2 