### PR TITLE
Add Windows Compatibility for Top 5 Process

### DIFF
--- a/memory.go
+++ b/memory.go
@@ -46,15 +46,20 @@ func GetTopProcesses() {
 			panic(err)
 		}
 
+		//Windows Compatiblilty(Leave out the System Idle Process), for more info refer #30
+		if processes[0].Pid==0 {
+			processes = processes[1:]
+		}
+
 		sort.Slice(processes, func(i, j int) bool {
 			memoryPercentOfIthProcess, err := processes[i].MemoryPercent()
 			if err != nil {
-				StandardPrinter(ErrorRedColor, "Could not retrieve memory usage details.")
+				StandardPrinter(ErrorRedColor, "Process memory usage access denied.") //More descriptive error
 				panic(err)
 			}
 			memoryPercentOfJthProcess, err := processes[j].MemoryPercent()
 			if err != nil {
-				StandardPrinter(ErrorRedColor, "Could not retrieve memory usage details.")
+				StandardPrinter(ErrorRedColor, "Process memory usage access denied.") //More descriptive error
 				panic(err)
 			}
 			return memoryPercentOfIthProcess > memoryPercentOfJthProcess
@@ -63,7 +68,7 @@ func GetTopProcesses() {
 		for i := 0; i < 5; i++ {
 			memoryPercentOfIthProcess, err := processes[i].MemoryPercent()
 			if err != nil {
-				StandardPrinter(ErrorRedColor, "Could not retrieve memory usage details.")
+				StandardPrinter(ErrorRedColor, "Process memory usage access denied.") //More descriptive error
 				panic(err)
 			}
 			strOutput += fmt.Sprintf("PID: %5d, memory %%: %2.1f\n", processes[i].Pid, memoryPercentOfIthProcess)

--- a/memory.go
+++ b/memory.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"sort"
-
+	"runtime"
 	"github.com/shirou/gopsutil/disk"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/shirou/gopsutil/process"
@@ -47,8 +47,15 @@ func GetTopProcesses() {
 		}
 
 		//Windows Compatiblilty(Leave out the System Idle Process), for more info refer #30
+<<<<<<< Updated upstream
 		if processes[0].Pid==0 {
 			processes = processes[1:]
+=======
+		if runtime.GOOS == "windows" {
+			if processes[0].Pid == 0 {
+				processes = processes[1:]
+			}
+>>>>>>> Stashed changes
 		}
 
 		sort.Slice(processes, func(i, j int) bool {

--- a/memory.go
+++ b/memory.go
@@ -47,15 +47,11 @@ func GetTopProcesses() {
 		}
 
 		//Windows Compatiblilty(Leave out the System Idle Process), for more info refer #30
-<<<<<<< Updated upstream
-		if processes[0].Pid==0 {
-			processes = processes[1:]
-=======
+
 		if runtime.GOOS == "windows" {
 			if processes[0].Pid == 0 {
 				processes = processes[1:]
 			}
->>>>>>> Stashed changes
 		}
 
 		sort.Slice(processes, func(i, j int) bool {


### PR DESCRIPTION
Fixes Bug #30 

- [x] Added Windows Compatibility for leaving out System Idle Process for Calculating Top 5 Process with memory usage.