### PR TITLE
Parametrise number of top ps

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,14 +15,15 @@ const (
 )
 
 var (
-	showCPUInfo  *bool
-	showCPUUsage *bool
-	showRAM      *bool
-	showDisk     *bool
-	showLocalIP  *bool
-	showPublicIP *bool
-	showAll      *bool
-	show5TopRAM  *bool
+	showCPUInfo             *bool
+	showCPUUsage            *bool
+	showRAM                 *bool
+	showDisk                *bool
+	showLocalIP             *bool
+	showPublicIP            *bool
+	showAll                 *bool
+	showNTopRAM             *bool
+	numberOfProcessesToShow *int
 )
 
 func main() {
@@ -33,7 +34,8 @@ func main() {
 	showDisk = flag.Bool("disk", false, "Show disk usage")
 	showLocalIP = flag.Bool("local-ip", false, "Show local IP address")
 	showPublicIP = flag.Bool("public-ip", false, "Show public IP address")
-	show5TopRAM = flag.Bool("top5-ram", false, "Show top 5 process that consume the most memory")
+	showNTopRAM = flag.Bool("top-ram", false, "Show top n process that consume the most memory")
+	numberOfProcessesToShow = flag.Int("n-proc", 5, "number of processes to show")
 	showAll = flag.Bool("all", false, "Show all stats")
 	flag.Parse()
 
@@ -52,7 +54,7 @@ func main() {
 		{*showDisk, GetDiskUsage},
 		{*showLocalIP, GetLocalIPAddress},
 		{*showPublicIP, GetPublicIPAddress},
-		{*show5TopRAM, GetTopProcesses},
+		{*showNTopRAM, func() { GetTopProcesses(*numberOfProcessesToShow) }},
 	}
 	for _, pair := range functionsWithConditions {
 		if *showAll || pair.condition {

--- a/memory.go
+++ b/memory.go
@@ -7,6 +7,7 @@ import (
 	"github.com/shirou/gopsutil/process"
 	"runtime"
 	"sort"
+	"strings"
 )
 
 func getReadableSize(sizeInBytes uint64) (readableSizeString string) {
@@ -42,7 +43,7 @@ func GetRamUsage() {
 }
 
 // GetTopProcesses print out the top 5 process that are consuming most RAM
-func GetTopProcesses() {
+func GetTopProcesses(numberOfRequestedProcesses int) {
 	processes, err := process.Processes()
 	if err != nil {
 		StandardPrinter(ErrorRedColor, "Could not retrieve running process list.")
@@ -85,15 +86,27 @@ func GetTopProcesses() {
 		return memoryPercentOfIthProcess > memoryPercentOfJthProcess
 	})
 
-	ResultPrinter("Top 5 processes by memory usage: \n", "")
-	for i := 0; i < 5; i++ {
+	howManyProcessesToShow := numberOfRequestedProcesses
+	if len(processes) < howManyProcessesToShow { howManyProcessesToShow = len(processes) }
+
+	maxIndexAsStringLength := len(fmt.Sprintf("%d", howManyProcessesToShow))
+	topProcessesHeader := fmt.Sprintf("Top %d processes by memory usage:", howManyProcessesToShow)
+	ResultPrinter(topProcessesHeader, "")
+
+	for i := 0; i < howManyProcessesToShow; i++ {
 		memoryPercentOfIthProcess, err := processes[i].MemoryPercent()
 		if err != nil {
 			StandardPrinter(ErrorRedColor, "Process memory usage access denied.") //More descriptive error
 			panic(err)
 		}
-		fmt.Printf("\t%d. %s %5d, %s %2.1f%%\n",
-			i+1,
+
+		indexAsString := fmt.Sprintf("%d", i + 1)
+		indexWithSpaces := fmt.Sprintf("%s%s",
+			strings.Repeat(" ", maxIndexAsStringLength - len(indexAsString)),
+			indexAsString,
+		)
+		fmt.Printf("\t%s. %s %5d, %s %2.1f%%\n",
+			indexWithSpaces,
 			fmt.Sprintf(BoldWhite, "PID:"),
 			processes[i].Pid,
 			fmt.Sprintf(BoldWhite, "memory:"),

--- a/memory.go
+++ b/memory.go
@@ -43,7 +43,6 @@ func GetRamUsage() {
 
 // GetTopProcesses print out the top 5 process that are consuming most RAM
 func GetTopProcesses() {
-	strOutput := ""
 	processes, err := process.Processes()
 	if err != nil {
 		StandardPrinter(ErrorRedColor, "Could not retrieve running process list.")
@@ -86,15 +85,20 @@ func GetTopProcesses() {
 		return memoryPercentOfIthProcess > memoryPercentOfJthProcess
 	})
 
+	ResultPrinter("Top 5 processes by memory usage: \n", "")
 	for i := 0; i < 5; i++ {
 		memoryPercentOfIthProcess, err := processes[i].MemoryPercent()
 		if err != nil {
 			StandardPrinter(ErrorRedColor, "Process memory usage access denied.") //More descriptive error
 			panic(err)
 		}
-		strOutput += fmt.Sprintf("PID: %5d, memory %%: %2.1f\n", processes[i].Pid, memoryPercentOfIthProcess)
+		fmt.Printf("\t%d. %s %5d, %s %2.1f%%\n",
+			i+1,
+			fmt.Sprintf(BoldWhite, "PID:"),
+			processes[i].Pid,
+			fmt.Sprintf(BoldWhite, "memory:"),
+			memoryPercentOfIthProcess)
 	}
-	ResultPrinter("Top 5 processes by memory usage: \n", strOutput)
 }
 
 func GetDiskUsage() {


### PR DESCRIPTION
This PR is dependent on #35.

It enables user to specify the number of top memory consuming processes to be displayed.
![image](https://user-images.githubusercontent.com/26343953/94940007-32b0f300-04d3-11eb-9a24-7d18694c429a.png)

