### PR TITLE
Add Get PCI Devices for Windows and Linux,  Rename White Color

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
+	github.com/jaypipes/pcidb v0.5.0
 	github.com/shirou/gopsutil v2.20.8+incompatible
 	golang.org/x/sys v0.0.0-20200929083018-4d22bbb62b3c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module termiboard
 go 1.14
 
 require (
-	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
+	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
 	github.com/go-ole/go-ole v1.2.4 // indirect
-	github.com/jaypipes/pcidb v0.5.0
+	github.com/jaypipes/ghw v0.6.1 // indirect
 	github.com/shirou/gopsutil v2.20.8+incompatible
 	golang.org/x/sys v0.0.0-20200929083018-4d22bbb62b3c // indirect
 )

--- a/main.go
+++ b/main.go
@@ -10,19 +10,21 @@ const (
 	BannerBlueColor    = "\033[1;36m%s\033[0m"
 	WarningYellowColor = "\033[1;33m%s\033[0m"
 	ErrorRedColor      = "\033[1;31m%s\033[0m"
-	BoldWhite          = "\033[1;37m%s\033[0m"
+	BoldGreenColor     = "\033[1;32m%s\033[0m"
+	BoldWhiteColor     = "\033[1;37m%s\033[0m"
 	None               = "\033[0m%s\033[0m"
 )
 
 var (
-	showCPUInfo  *bool
-	showCPUUsage *bool
-	showRAM      *bool
-	showDisk     *bool
-	showLocalIP  *bool
-	showPublicIP *bool
-	showAll      *bool
-	show5TopRAM  *bool
+	showCPUInfo    *bool
+	showCPUUsage   *bool
+	showRAM        *bool
+	showDisk       *bool
+	showLocalIP    *bool
+	showPublicIP   *bool
+	showAll        *bool
+	show5TopRAM    *bool
+	showPCIDevices *bool
 )
 
 func main() {
@@ -34,6 +36,7 @@ func main() {
 	showLocalIP = flag.Bool("local-ip", false, "Show local IP address")
 	showPublicIP = flag.Bool("public-ip", false, "Show public IP address")
 	show5TopRAM = flag.Bool("top5-ram", false, "Show top 5 process that consume the most memory")
+	showPCIDevices = flag.Bool("pci-devices", false, "Show all PCI Devices")
 	showAll = flag.Bool("all", false, "Show all stats")
 	flag.Parse()
 
@@ -50,6 +53,7 @@ func main() {
 	GetLocalIPAddress()
 	GetPublicIPAddress()
 	GetTopProcesses()
+	GetPCIDevices()
 }
 
 func printBanner() {

--- a/main.go
+++ b/main.go
@@ -57,10 +57,22 @@ func main() {
 		{*showLocalIP, GetLocalIPAddress},
 		{*showPublicIP, GetPublicIPAddress},
 		{*show5TopRAM, GetTopProcesses},
-		{*showPCIDevices, GetPCIDevices},
 	}
 	for _, pair := range functionsWithConditions {
 		if *showAll || pair.condition {
+			pair.function()
+		}
+	}
+
+	//For Function called using their flags only
+	var functionCallArgs = []struct {
+		condition bool
+		function func()
+	}{
+		{*showPCIDevices, GetPCIDevices},
+	}
+	for _, pair := range functionCallArgs {
+		if pair.condition {
 			pair.function()
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ const (
 	BannerBlueColor    = "\033[1;36m%s\033[0m"
 	WarningYellowColor = "\033[1;33m%s\033[0m"
 	ErrorRedColor      = "\033[1;31m%s\033[0m"
-	BoldGreenColor     = "\033[1;32m%s\033[0m"
 	BoldWhiteColor     = "\033[1;37m%s\033[0m"
 	None               = "\033[0m%s\033[0m"
 )

--- a/main.go
+++ b/main.go
@@ -44,16 +44,26 @@ func main() {
 		*showAll = true
 	}
 
-	printBanner()
-	StandardPrinter(WarningYellowColor, "v1.0")
-	GetCpuInfo()
-	GetCpuUsage()
-	GetRamUsage()
-	GetDiskUsage()
-	GetLocalIPAddress()
-	GetPublicIPAddress()
-	GetTopProcesses()
-	GetPCIDevices()
+	var functionsWithConditions = []struct {
+		condition bool
+		function  func()
+	}{
+		{true, printBanner},
+		{true, func() { StandardPrinter(WarningYellowColor, "v1.0") }},
+		{*showCPUInfo, GetCpuInfo},
+		{*showCPUUsage, GetCpuUsage},
+		{*showRAM, GetRamUsage},
+		{*showDisk, GetDiskUsage},
+		{*showLocalIP, GetLocalIPAddress},
+		{*showPublicIP, GetPublicIPAddress},
+		{*show5TopRAM, GetTopProcesses},
+		{*showPCIDevices, GetPCIDevices},
+	}
+	for _, pair := range functionsWithConditions {
+		if *showAll || pair.condition {
+			pair.function()
+		}
+	}
 }
 
 func printBanner() {

--- a/memory.go
+++ b/memory.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"sort"
-	"runtime"
 	"github.com/shirou/gopsutil/disk"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/shirou/gopsutil/process"
+	"runtime"
+	"sort"
 )
 
 func getReadableSize(sizeInBytes uint64) (readableSizeString string) {
@@ -53,7 +53,6 @@ func GetTopProcesses() {
 		}
 
 		//Windows Compatiblilty(Leave out the System Idle Process), for more info refer #30
-
 		if runtime.GOOS == "windows" {
 			if processes[0].Pid == 0 {
 				processes = processes[1:]

--- a/network.go
+++ b/network.go
@@ -8,42 +8,38 @@ import (
 )
 
 func GetPublicIPAddress() {
-	if *showAll || *showPublicIP {
-		URL := "https://api.ipify.org" //Using Third Party Service to Ping
-		resp, err := http.Get(URL)     //Get the JSON Response
-		if err != nil {
-			StandardPrinter(ErrorRedColor, "Could not get response from "+URL)
-			StandardPrinter(WarningYellowColor, "Check your Internet Connection")
-			panic(err) //Exit upon error, below code must not be executed
-		}
-		defer resp.Body.Close()              //The client must close the response body when finished with it
-		IP, err := ioutil.ReadAll(resp.Body) //Reading all data from a io.Reader until EOF
-		if err != nil {
-			StandardPrinter(ErrorRedColor, "Could not find IPv4 Address")
-			panic(err) //Exit upon error, below code must not be executed
-		}
-		ResultPrinter("Public IPv4 Address: ", string(IP)) //Cast []bByte to String and return
+	URL := "https://api.ipify.org" //Using Third Party Service to Ping
+	resp, err := http.Get(URL)     //Get the JSON Response
+	if err != nil {
+		StandardPrinter(ErrorRedColor, "Could not get response from "+URL)
+		StandardPrinter(WarningYellowColor, "Check your Internet Connection")
+		panic(err) //Exit upon error, below code must not be executed
 	}
+	defer resp.Body.Close()              //The client must close the response body when finished with it
+	IP, err := ioutil.ReadAll(resp.Body) //Reading all data from a io.Reader until EOF
+	if err != nil {
+		StandardPrinter(ErrorRedColor, "Could not find IPv4 Address")
+		panic(err) //Exit upon error, below code must not be executed
+	}
+	ResultPrinter("Public IPv4 Address: ", string(IP)) //Cast []bByte to String and return
 }
 
 func GetLocalIPAddress() {
-	if *showAll || *showLocalIP {
-		networkInterfaces, err := net.Interfaces() //Get the name of all Network Interface Cards
-		if err != nil {                            //Error Handling
-			StandardPrinter(ErrorRedColor, "Unfortunately it is not possible to get your local IP")
-			panic(err) //Exit upon error, below code must not be executed
-		}
-		ResultPrinter("Local IP Address:", "")
-		for _, networkInterface := range networkInterfaces { //Iterate over each Network Interface Card
-			StandardPrinter(BoldWhiteColor, "\t["+string(networkInterface.Name)+"] "+networkInterface.HardwareAddr.String()) // Print Name and Hardware Address
-			interfaceAddresses, err := networkInterface.Addrs()                                                              //Get the Internet Addresses of a Network Interface
-			if err == nil {
-				for _, interfaceAddress := range interfaceAddresses {
-					if strings.Contains(interfaceAddress.String(), ".") { //Check for IPv4 Address
-						StandardPrinter(None, "\t\t"+"IPv4"+" -> "+interfaceAddress.String())
-					} else if strings.Contains(interfaceAddress.String(), ":") { //Check for IPv6 Address
-						StandardPrinter(None, "\t\t"+"IPv6"+" -> "+interfaceAddress.String())
-					}
+	networkInterfaces, err := net.Interfaces() //Get the name of all Network Interface Cards
+	if err != nil {                            //Error Handling
+		StandardPrinter(ErrorRedColor, "Unfortunately it is not possible to get your local IP")
+		panic(err) //Exit upon error, below code must not be executed
+	}
+	ResultPrinter("Local IP Address:", "")
+	for _, networkInterface := range networkInterfaces { //Iterate over each Network Interface Card
+		StandardPrinter(BoldWhiteColor, "\t["+string(networkInterface.Name)+"] "+networkInterface.HardwareAddr.String()) // Print Name and Hardware Address
+		interfaceAddresses, err := networkInterface.Addrs()                                                         //Get the Internet Addresses of a Network Interface
+		if err == nil {
+			for _, interfaceAddress := range interfaceAddresses {
+				if strings.Contains(interfaceAddress.String(), ".") { //Check for IPv4 Address
+					StandardPrinter(None, "\t\t"+"IPv4"+" -> "+interfaceAddress.String())
+				} else if strings.Contains(interfaceAddress.String(), ":") { //Check for IPv6 Address
+					StandardPrinter(None, "\t\t"+"IPv6"+" -> "+interfaceAddress.String())
 				}
 			}
 		}

--- a/network.go
+++ b/network.go
@@ -35,8 +35,8 @@ func GetLocalIPAddress() {
 		}
 		ResultPrinter("Local IP Address:", "")
 		for _, networkInterface := range networkInterfaces { //Iterate over each Network Interface Card
-			StandardPrinter(BoldWhite, "\t["+string(networkInterface.Name)+"] "+networkInterface.HardwareAddr.String()) // Print Name and Hardware Address
-			interfaceAddresses, err := networkInterface.Addrs()                                                         //Get the Internet Addresses of a Network Interface
+			StandardPrinter(BoldWhiteColor, "\t["+string(networkInterface.Name)+"] "+networkInterface.HardwareAddr.String()) // Print Name and Hardware Address
+			interfaceAddresses, err := networkInterface.Addrs()                                                              //Get the Internet Addresses of a Network Interface
 			if err == nil {
 				for _, interfaceAddress := range interfaceAddresses {
 					if strings.Contains(interfaceAddress.String(), ".") { //Check for IPv4 Address

--- a/pci.go
+++ b/pci.go
@@ -5,21 +5,19 @@ import (
 )
 
 func GetPCIDevices() {
-	if *showPCIDevices {
-		ResultPrinter("PCI Bus Devices:", "")
-		pci, err := pcidb.New()
-		if err != nil {
-			StandardPrinter(ErrorRedColor, "Error getting PCI Devices Data")
-			panic(err)
-		}
+	ResultPrinter("PCI Bus Devices:", "")
+	pci, err := pcidb.New()
+	if err != nil {
+		StandardPrinter(ErrorRedColor, "Error getting PCI Devices Data")
+		panic(err)
+	}
 
-		for _, deviceClass := range pci.Classes {
-			StandardPrinter(BoldWhiteColor, "\tDevice class: [" + string(deviceClass.Name) + "] "+ string(deviceClass.ID))
-			for _, deviceSubclass := range deviceClass.Subclasses {
-				StandardPrinter(None, "\t\tDevice subclass:" + string(deviceSubclass.Name) + " "+ string(deviceSubclass.ID))
-				for _, programmingInterface := range deviceSubclass.ProgrammingInterfaces {
-					StandardPrinter(BoldGreenColor, "\t\t\tProgramming interface" + string(programmingInterface.Name) + " " + string(programmingInterface.ID))
-				}
+	for _, deviceClass := range pci.Classes {
+		StandardPrinter(BoldWhiteColor, "\tDevice class: ["+string(deviceClass.Name)+"] "+string(deviceClass.ID))
+		for _, deviceSubclass := range deviceClass.Subclasses {
+			StandardPrinter(None, "\t\tDevice subclass:"+string(deviceSubclass.Name)+" "+string(deviceSubclass.ID))
+			for _, programmingInterface := range deviceSubclass.ProgrammingInterfaces {
+				StandardPrinter(BoldGreenColor, "\t\t\tProgramming interface"+string(programmingInterface.Name)+" "+string(programmingInterface.ID))
 			}
 		}
 	}

--- a/pci.go
+++ b/pci.go
@@ -1,24 +1,60 @@
+// +build !windows
+
 package main
 
 import (
-	"github.com/jaypipes/pcidb"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/jaypipes/ghw"
 )
 
 func GetPCIDevices() {
-	ResultPrinter("PCI Bus Devices:", "")
-	pci, err := pcidb.New()
+
+	ResultPrinter("Host PCI devices:", "")
+
+	//Create a Tab writer to STDout with padding of 3, space between column and Left Align column
+	const padding = 3
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, padding, ' ', 0)
+	//Always Flush the Tab Writer because it is line buffered
+	defer w.Flush()
+
+	//TODO: Implement StandardPrinter for tabwriter
+	//Print Header Row of the table
+	fmt.Fprintln(w, "Class\tManufacturer\tName\t")
+
+	////TODO: Implement StandardPrinter for tabwriter
+	//Print Seperator for Header and Data of the table
+	fmt.Fprintln(w, "-----\t------------\t----\t")
+
+	pci, err := ghw.PCI()
 	if err != nil {
-		StandardPrinter(ErrorRedColor, "Error getting PCI Devices Data")
-		panic(err)
+		fmt.Printf("Error getting PCI info: %v", err)
 	}
 
-	for _, deviceClass := range pci.Classes {
-		StandardPrinter(BoldWhiteColor, "\tDevice class: ["+string(deviceClass.Name)+"] "+string(deviceClass.ID))
-		for _, deviceSubclass := range deviceClass.Subclasses {
-			StandardPrinter(None, "\t\tDevice subclass:"+string(deviceSubclass.Name)+" "+string(deviceSubclass.ID))
-			for _, programmingInterface := range deviceSubclass.ProgrammingInterfaces {
-				StandardPrinter(BoldGreenColor, "\t\t\tProgramming interface"+string(programmingInterface.Name)+" "+string(programmingInterface.ID))
-			}
-		}
+	devices := pci.ListDevices()
+	if len(devices) == 0 {
+		fmt.Printf("error: could not retrieve PCI devices\n")
+		return
 	}
+
+	for _, device := range devices {
+		vendor := device.Vendor
+		vendorName := vendor.Name
+		if len(vendor.Name) > 20 {
+			//Product Name Shorten
+			vendorName = string([]byte(vendorName)[0:17]) + "..."
+		}
+		product := device.Product
+		productName := product.Name
+		if len(product.Name) > 40 {
+			//Product Name Shorten
+			productName = string([]byte(productName)[0:37]) + "..."
+		}
+		//TODO: Implement StandardPrinter for tabwriter
+		//Print Data Row of the table
+		fmt.Fprintln(w, device.Class.Name+"\t"+vendorName+"\t"+productName+"\t")
+	}
+
 }

--- a/pci.go
+++ b/pci.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"github.com/jaypipes/pcidb"
+)
+
+func GetPCIDevices() {
+	if *showPCIDevices {
+		ResultPrinter("PCI Bus Devices:", "")
+		pci, err := pcidb.New()
+		if err != nil {
+			StandardPrinter(ErrorRedColor, "Error getting PCI Devices Data")
+			panic(err)
+		}
+
+		for _, deviceClass := range pci.Classes {
+			StandardPrinter(BoldWhiteColor, "\tDevice class: [" + string(deviceClass.Name) + "] "+ string(deviceClass.ID))
+			for _, deviceSubclass := range deviceClass.Subclasses {
+				StandardPrinter(None, "\t\tDevice subclass:" + string(deviceSubclass.Name) + " "+ string(deviceSubclass.ID))
+				for _, programmingInterface := range deviceSubclass.ProgrammingInterfaces {
+					StandardPrinter(BoldGreenColor, "\t\t\tProgramming interface" + string(programmingInterface.Name) + " " + string(programmingInterface.ID))
+				}
+			}
+		}
+	}
+}

--- a/pci_windows.go
+++ b/pci_windows.go
@@ -1,0 +1,53 @@
+// Reference Documentation: https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-pnpentity
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/StackExchange/wmi"
+)
+
+//Parameters are selected such that they match with Linux Counterpart as well
+type PnPEntity struct {
+	PNPClass     string
+	Name         string
+	Manufacturer string
+}
+
+func GetPCIDevices() {
+
+	ResultPrinter("Host PCI devices:", "")
+
+	//Create a Tab writer to STDout with padding of 3, space between column and Left Align column
+	const padding = 3
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, padding, ' ', 0)
+	//Always Flush the Tab Writer because it is line buffered
+	defer w.Flush()
+
+	//Create a slice for holding info about PCIDevices with PnPEntity properties
+	var PCIDevices []PnPEntity
+	//Query to select only the PCI Devices from Win32_PnPEntity
+	err := wmi.Query("Select * from Win32_PnPEntity where PNPDeviceID like '%PCI%'", &PCIDevices)
+	if err != nil {
+		StandardPrinter(ErrorRedColor, "Could not retrieve PCI Devices")
+		panic(err)
+		return
+	}
+
+	//TODO: Implement StandardPrinter for tabwriter
+	//Print Header Row of the table
+	fmt.Fprintln(w, "Class\tManufacturer\tName\t")
+
+	//TODO: Implement StandardPrinter for tabwriter
+	//Print Seperator for Header and Data of the table
+	fmt.Fprintln(w, "-----\t------------\t----\t")
+
+	for _, PCIDevice := range PCIDevices {
+		//TODO: Implement StandardPrinter for tabwriter
+		//Print Data Row of the table
+		fmt.Fprintln(w, PCIDevice.PNPClass+"\t"+PCIDevice.Manufacturer+"\t"+PCIDevice.Name+"\t")
+	}
+
+}


### PR DESCRIPTION
Partially Fixes: ls* Family Issue
## What's new
- [x] Added Get PCI Devices Function For Windows and Linux
- [x] Renamed White Color to match other colors name
## Usage
To see the output of PCI Devices:
do as
`./termiboard.exe -pci-devices`

## Reference Docs: 
1. For Windows: [Win32_PNPEntity](https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-pnpentity) and to query it: [StackExchange/wmi pkg](https://pkg.go.dev/github.com/StackExchange/wmi)

2. For Linux: [jaypipes/ghw pkg](https://godoc.org/github.com/jaypipes/ghw)