### PR TITLE
Add Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 go.sum
 .idea/
+vendor/
 termiboard.exe
 termiboard

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Build variables
 PROJECT_NAME = $(shell basename "$(PWD)")
-BUILD_DIR = bin
+BASE=$(shell pwd)
+BUILD_DIR=$(BASE)/bin
 VERSION ?= $(shell git tag --points-at HEAD | tail -n 1)
 BUILD_DATE = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 COMMIT_SHA = $(shell git rev-parse --short HEAD)
@@ -23,6 +24,10 @@ test: dep ## Run unit tests
 build: test ## Build a binary executable file
 	@echo "  >  Build binary"
 	go build ${LDFLAGS} -o ${BUILD_DIR}/${PROJECT_NAME}
+
+clean: ## Clean build cache
+	@echo "  >  Cleaning build cache"
+	go clean
 
 .PHONY: run
 run: ## Run current version

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+# Build variables
+PROJECT_NAME = $(shell basename "$(PWD)")
+BUILD_DIR = bin
+VERSION ?= $(shell git tag --points-at HEAD | tail -n 1)
+BUILD_DATE = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+COMMIT_SHA = $(shell git rev-parse --short HEAD)
+LDFLAGS = -ldflags "-w -X main.version=${VERSION} -X main.buildDate=${BUILD_DATE} -X main.commit=${COMMIT_SHA}"
+PACKAGE = $(shell go list -m)
+
+.PHONY: dep
+dep: ## Install dependencies
+	@echo "  >  Install dependencies"
+	@go mod tidy
+	@go mod download
+	@go mod vendor
+
+.PHONY: test
+test: dep ## Run unit tests
+	@echo "  >  Run tests"
+	@go test -v ./...
+
+.PHONY: build
+build: test ## Build a binary executable file
+	@echo "  >  Build binary"
+	go build ${LDFLAGS} -o ${BUILD_DIR}/${PROJECT_NAME}
+
+.PHONY: run
+run: ## Run current version
+	./bin/${PROJECT_NAME}
+
+.PHONY: rerun
+rerun: build run ## Build and Run
+
+.PHONY: printvars
+printvars: ## Print variables (including Makefile)
+	$(foreach v, $(filter-out .VARIABLES,$(.VARIABLES)), $(info $(v) = $($(v))))
+	@echo "  >  Print vars done"
+
+.PHONY: help
+.DEFAULT_GOAL := help
+help: ## Print this message
+	@echo "Makefile usage help:"
+	@echo "------"
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+

--- a/main.go
+++ b/main.go
@@ -5,6 +5,15 @@ import (
 	"fmt"
 )
 
+var (
+	// Provisioned by ldflags
+	version   string
+	buildDate string
+	commit    string
+)
+
+var versionString = fmt.Sprintf("v1.0 tag: %s, date: %s, commit: %s", version, buildDate, commit)
+
 const (
 	InfoOrangeColor    = "\033[1;34m%s\033[0m"
 	BannerBlueColor    = "\033[1;36m%s\033[0m"
@@ -45,7 +54,7 @@ func main() {
 		function  func()
 	}{
 		{true, printBanner},
-		{true, func() { StandardPrinter(WarningYellowColor, "v1.0") }},
+		{true, func() { StandardPrinter(WarningYellowColor, versionString) }},
 		{*showCPUInfo, GetCpuInfo},
 		{*showCPUUsage, GetCpuUsage},
 		{*showRAM, GetRamUsage},


### PR DESCRIPTION
Makefile help newcomers to understand what to do with project.

By running:
```bash
$ make help
```
or just
```bash
$ make
```
there will be help message with all available commands.

Help message parsed from Makefile itself, by finding
`##` comments after command name.

Currently usefull commands are:
- *dep* - install dependencies and make vendoring folder
- *test*- run unit tests, but before it runs `dep`
- *build* - run test and build a binary into ./bin folder
- *run* - just execute binary
- *rerun* - build and run
- *printvars* - print all variables available for make
its usefull when you need to debug some settings

On top of Makefile there are variables for all these commands, like:
- PROJECT_NAME
- BUILD_DIR
- VERSION
- BUILD_DATE
- COMMIT_SHA
- and LDFLAGS

LDFLAGS used on binary compilation, to inject some build data
and get this information inside app.

Also this commit contains small changes in forming of version string

There is a good practices to add version with git tags, but also
a commit message and build date.